### PR TITLE
add SAML backchannel logout

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <version>3.6.1-SNAPSHOT</version>
 
     <properties>
-        <java.version>1.8</java.version>
+        <java.version>11</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -113,6 +113,12 @@
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-features-logging</artifactId>
             <version>${apache-cxf.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+            <version>4.10.0</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/io/cloudtrust/testclient/pac4j/CustomSAML2CredentialsExtractor.java
+++ b/src/main/java/io/cloudtrust/testclient/pac4j/CustomSAML2CredentialsExtractor.java
@@ -16,6 +16,8 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.Optional;
 
 public class CustomSAML2CredentialsExtractor extends SAML2CredentialsExtractor {
@@ -36,7 +38,7 @@ public class CustomSAML2CredentialsExtractor extends SAML2CredentialsExtractor {
                 AssertionMarshaller marshaller = new AssertionMarshaller();
                 Element plaintextElement = marshaller.marshall(assertion);
                 String originalAssertionString = xmlToString(plaintextElement);
-                context.setResponseHeader("saml_assertion", originalAssertionString);
+                context.setResponseHeader("saml_assertion", Base64.getEncoder().encodeToString(originalAssertionString.getBytes(StandardCharsets.UTF_8)));
             }
         } catch (MarshallingException | TransformerException e) {
             System.err.println("Unexpected issue while marshalling the assertion to String");

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -31,6 +31,21 @@
 				}
 				xhr.send();
 			}
+
+			function backchannelLogout() {
+				var xhr = new XMLHttpRequest();
+				xhr.open("get", "/backchannel-logout", true);
+				xhr.onreadystatechange = function() {
+					if (xhr.readyState === 4) {
+						if (xhr.status === 200) {
+							location = "/";
+						} else {
+							alert("backchannel logout failed");
+						}
+					}
+				}
+				xhr.send();
+			}
 		</script>
 
 		<!-- Header -->
@@ -89,6 +104,8 @@
 					<header>
 						<h3>TOKEN INFORMATION</h3>
 						<button id="renewSamlButton" type="button" style="background-color: white;" onclick="renewSaml()" th:if="${samlArtifactBinding}">Renew assertion</button>
+						<br>
+						<button id="backchannelLogoutButton" type="button" style="background-color: white;" onclick="backchannelLogout()">Backchannel logout</button>
 					</header>
 					<p><span style="white-space: pre; word-break: break-all;" th:if="${tokenInfo != null}" th:text="${tokenInfo}"></span></p>
 				</div>


### PR DESCRIPTION
This PR adds the ability to trigger a backchannel logout from the SP to the IDP. When the response comes back, it destroys the session.