### PR TITLE
[CLOUDTRUST-7661] Fix ACR values filter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>io.cloudtrust</groupId>
     <artifactId>IdPTestClient</artifactId>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>3.10.0-SNAPSHOT</version>
 
     <properties>
         <java.version>11</java.version>

--- a/src/main/java/io/cloudtrust/testclient/pac4j/OidcAcrValuesFilter.java
+++ b/src/main/java/io/cloudtrust/testclient/pac4j/OidcAcrValuesFilter.java
@@ -1,5 +1,6 @@
 package io.cloudtrust.testclient.pac4j;
 
+import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.pac4j.core.client.Client;
 import org.pac4j.core.config.Config;
@@ -25,6 +26,11 @@ public class OidcAcrValuesFilter extends OncePerRequestFilter {
     private final Config config;
     private final SecurityFilter securityFilter;
 
+    private static final String ACR_VALUES_PARAM = "acr_values";
+
+    // Lock to protect configuration modifications
+    private static final Object ACR_VALUES_LOCK = new Object();
+
     public OidcAcrValuesFilter(Config config, SecurityFilter securityFilter) {
         this.config = config;
         this.securityFilter = securityFilter;
@@ -34,21 +40,24 @@ public class OidcAcrValuesFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, @NotNull HttpServletResponse response, @NotNull FilterChain filterChain)
             throws ServletException, IOException {
 
-        String acrValues = request.getParameter("acr_values");
+        String acrValues = request.getParameter(ACR_VALUES_PARAM);
 
-        if (acrValues != null && !acrValues.isEmpty()) {
+        synchronized (ACR_VALUES_LOCK) {
             // Get the OIDC client and update custom params
             Optional<Client> oidcClientOpt = config.getClients().findClient("oidcClient");
             if (oidcClientOpt.isPresent()) {
                 OidcClient oidcClient = (OidcClient) oidcClientOpt.get();
                 OidcConfiguration oidcConfig = oidcClient.getConfiguration();
 
-                Map<String, String> customParams = new HashMap<>(oidcConfig.getCustomParams());
-                customParams.put("acr_values", acrValues);
-                oidcConfig.setCustomParams(customParams);
+                oidcConfig.getCustomParams().remove(ACR_VALUES_PARAM);
+                if (!StringUtils.isBlank(acrValues)) {
+                    Map<String, String> customParams = new HashMap<>(oidcConfig.getCustomParams());
+                    customParams.put(ACR_VALUES_PARAM, acrValues);
+                    oidcConfig.setCustomParams(customParams);
+                }
             }
-        }
 
-        securityFilter.doFilter(request, response, filterChain);
+            securityFilter.doFilter(request, response, filterChain);
+        }
     }
 }


### PR DESCRIPTION
The ACR values are persisted in the same OidClient config object. There are two problems related to that:

1. If we enter a value in the form, logout, then try to re-login with no value, the old value is still used => Clear the value in the config before updating
2. If multiple users try to login, both threads may modify the object concurrently => Surround the logic with a synchronized block.